### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+6] - November 7, 2023
+
+* Automated dependency updates
+
+
 ## [4.0.0+5] - October 10, 2023
 
 * Automated dependency updates
@@ -341,6 +346,7 @@
 ## [1.0.0] - December 2nd, 2021
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+3'
+version: '1.0.0+4'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -10,7 +10,7 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   ionicons_named: '^1.3.1'
-  json_dynamic_widget: '^7.0.2'
+  json_dynamic_widget: '^7.0.4+1'
   json_dynamic_widget_plugin_ionicons: 
     path: '../'
   logging: '^1.2.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_ionicons'
 description: 'A plugin to the JSON Dynamic Widget to provide String name support for ionicons'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_ionicons'
-version: '4.0.0+5'
+version: '4.0.0+6'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,22 +17,22 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   ionicons_named: '^1.3.1'
-  json_class: '^3.0.0+5'
-  json_dynamic_widget: '^7.0.2'
-  json_theme: '^6.3.0'
+  json_class: '^3.0.0+8'
+  json_dynamic_widget: '^7.0.4+1'
+  json_theme: '^6.3.1'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  uuid: '^4.1.0'
+  uuid: '^4.2.0'
 
 false_secrets: 
   - 'example/web/index.html'
 
 dev_dependencies: 
   build_runner: '^2.4.6'
-  flutter_lints: '^2.0.3'
+  flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.1+1'
+  json_dynamic_widget_codegen: '^1.0.4'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_class`: 3.0.0+5 --> 3.0.0+8
  * `json_dynamic_widget`: 7.0.2 --> 7.0.4+1
  * `json_theme`: 6.3.0 --> 6.3.1
  * `uuid`: 4.1.0 --> 4.2.0

dev_dependencies:
  * `flutter_lints`: 2.0.3 --> 3.0.1
  * `json_dynamic_widget_codegen`: 1.0.1+1 --> 1.0.4


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Note: meta is pinned to version 1.9.1 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.9.1 and uuid >=4.2.0 depends on meta ^1.11.0, flutter_test from sdk is incompatible with uuid >=4.2.0.
So, because json_dynamic_widget_plugin_ionicons depends on both uuid ^4.2.0 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on uuid: flutter pub add uuid:^4.1.0

```


dependencies:
  * `json_dynamic_widget`: 7.0.2 --> 7.0.4+1


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.9.1 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter from sdk depends on meta 1.9.1 and uuid >=4.2.0 depends on meta ^1.11.0, flutter from sdk is incompatible with uuid >=4.2.0.
And because every version of json_dynamic_widget_plugin_ionicons from path depends on uuid ^4.2.0, flutter from sdk is incompatible with json_dynamic_widget_plugin_ionicons from path.
So, because example depends on both flutter from sdk and json_dynamic_widget_plugin_ionicons from path, version solving failed.

```

