### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+32] - December 31, 2024
+
+* Automated dependency updates
+
+
 ## [4.0.0+31] - December 10, 2024
 
 * Automated dependency updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+22'
+version: '1.0.0+23'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: 'flutter'
   ionicons_named: '^1.3.2+6'
-  json_dynamic_widget: '^7.3.1+13'
+  json_dynamic_widget: '^8.0.0'
   json_dynamic_widget_plugin_ionicons:
     path: '../'
   logging: '^1.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_ionicons'
 description: 'A plugin to the JSON Dynamic Widget to provide String name support for ionicons'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_ionicons'
-version: '4.0.0+31'
+version: '4.0.0+32'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -17,8 +17,8 @@ dependencies:
     sdk: 'flutter'
   ionicons_named: '^1.3.2+6'
   json_class: '^3.0.1'
-  json_dynamic_widget: '^7.3.1+13'
-  json_theme: '^6.5.4+1'
+  json_dynamic_widget: '^8.0.0'
+  json_theme: '^7.0.0+2'
   logging: '^1.3.0'
   meta: '^1.12.0'
   uuid: '^4.5.1'
@@ -27,11 +27,11 @@ false_secrets:
   - 'example/web/index.html'
 
 dev_dependencies:
-  build_runner: '^2.4.13'
+  build_runner: '^2.4.14'
   flutter_lints: '^5.0.0'
   flutter_test:
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+18'
+  json_dynamic_widget_codegen: '^2.0.0'
 
 permittedLicenses:
   - 'Apache-2.0'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_dynamic_widget`: 7.3.1+13 --> 8.0.0
  * `json_theme`: 6.5.4+1 --> 7.0.0+2

dev_dependencies:
  * `build_runner`: 2.4.13 --> 2.4.14
  * `json_dynamic_widget_codegen`: 1.0.6+18 --> 2.0.0


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/to/crash-reporting                                     ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...


Because source_gen ^1.0.0 depends on dart_style ^2.0.0 and dart_style ^2.3.7 depends on analyzer ^6.5.0, source_gen ^1.0.0 requires analyzer ^6.5.0 or dart_style >=2.0.0 <2.3.7.
And because json_dynamic_widget_codegen >=1.0.6+1 depends on analyzer >=6.2.0 <6.5.0, if json_dynamic_widget_codegen >=1.0.6+1 and source_gen ^1.0.0 then dart_style >=2.0.0 <2.3.7.
And because json_dynamic_widget_codegen >=1.0.4+4 depends on source_gen ^1.5.0 and build_runner >=2.4.14 depends on dart_style >=2.3.7 <4.0.0, json_dynamic_widget_codegen >=1.0.6+1 is incompatible with build_runner >=2.4.14.
So, because json_dynamic_widget_plugin_ionicons depends on both build_runner ^2.4.14 and json_dynamic_widget_codegen ^2.0.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on build_runner: flutter pub add dev:build_runner:^2.4.13
Failed to update packages.

```


dependencies:
  * `json_dynamic_widget`: 7.3.1+13 --> 8.0.0


Analysis Successful

