### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+39] - June 17, 2025
+
+* Automated dependency updates
+
+
 ## [4.0.0+38] - May 20, 2025
 
 * Automated dependency updates

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "json_dynamic_widget_plugin_ionicons"
 description: "A plugin to the JSON Dynamic Widget to provide String name support for ionicons"
 homepage: "https://github.com/peiffer-innovations/json_dynamic_widget_plugin_ionicons"
-version: "4.0.0+38"
+version: "4.0.0+39"
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -18,7 +18,7 @@ dependencies:
   ionicons_named: "^1.3.2+6"
   json_class: "^3.0.1"
   json_dynamic_widget: "^9.0.0+7"
-  json_theme: "^8.0.0+3"
+  json_theme: "^9.0.0+3"
   logging: "^1.3.0"
   meta: "^1.12.0"
   uuid: "^4.5.1"
@@ -27,8 +27,8 @@ false_secrets:
   - "example/web/index.html"
 
 dev_dependencies:
-  build_runner: "^2.4.15"
-  flutter_lints: "^5.0.0"
+  build_runner: "^2.5.0"
+  flutter_lints: "^6.0.0"
   flutter_test:
     sdk: "flutter"
   json_dynamic_widget_codegen: "^2.2.0"


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_theme`: 8.0.0+3 --> 9.0.0+3

dev_dependencies:
  * `build_runner`: 2.4.15 --> 2.5.0
  * `flutter_lints`: 5.0.0 --> 6.0.0


Error!!!
```
Resolving dependencies...


Because json_dynamic_widget_codegen >=2.1.0+3 depends on json_theme ^8.0.0+2 and json_dynamic_widget_plugin_ionicons depends on json_theme ^9.0.0+3, json_dynamic_widget_codegen >=2.1.0+3 is forbidden.
So, because json_dynamic_widget_plugin_ionicons depends on json_dynamic_widget_codegen ^2.2.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on json_theme: flutter pub add json_theme:'^8.0.0+3'
Failed to update packages.

```


