### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+39] - June 19, 2025
+
+* Automated dependency updates
+
+
 ## [4.0.0+38] - May 20, 2025
 
 * Automated dependency updates

--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "example"
 description: "Example app for the JsonDynamicWidget library"
 publish_to: "none"
-version: "1.0.0+28"
+version: "1.0.0+29"
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: "flutter"
   ionicons_named: "^1.3.2+6"
-  json_dynamic_widget: "^9.0.0+7"
+  json_dynamic_widget: "^10.0.1"
   json_dynamic_widget_plugin_ionicons:
     path: "../"
   logging: "^1.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "json_dynamic_widget_plugin_ionicons"
 description: "A plugin to the JSON Dynamic Widget to provide String name support for ionicons"
 homepage: "https://github.com/peiffer-innovations/json_dynamic_widget_plugin_ionicons"
-version: "4.0.0+38"
+version: "4.0.0+39"
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -17,8 +17,8 @@ dependencies:
     sdk: "flutter"
   ionicons_named: "^1.3.2+6"
   json_class: "^3.0.1"
-  json_dynamic_widget: "^9.0.0+7"
-  json_theme: "^8.0.0+3"
+  json_dynamic_widget: "^10.0.1"
+  json_theme: "^9.0.1"
   logging: "^1.3.0"
   meta: "^1.12.0"
   uuid: "^4.5.1"
@@ -27,11 +27,11 @@ false_secrets:
   - "example/web/index.html"
 
 dev_dependencies:
-  build_runner: "^2.4.15"
-  flutter_lints: "^5.0.0"
+  build_runner: "^2.5.2"
+  flutter_lints: "^6.0.0"
   flutter_test:
     sdk: "flutter"
-  json_dynamic_widget_codegen: "^2.2.0"
+  json_dynamic_widget_codegen: "^3.0.0"
 
 permittedLicenses:
   - "Apache-2.0"


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_dynamic_widget`: 9.0.0+7 --> 10.0.1
  * `json_theme`: 8.0.0+3 --> 9.0.1

dev_dependencies:
  * `build_runner`: 2.4.15 --> 2.5.2
  * `flutter_lints`: 5.0.0 --> 6.0.0
  * `json_dynamic_widget_codegen`: 2.2.0 --> 3.0.0


Error!!!
```
Resolving dependencies...
Downloading packages...
+ _fe_analyzer_shared 80.0.0 (82.0.0 available)
+ analyzer 7.3.0 (7.4.5 available)
+ args 2.7.0
+ asn1lib 1.6.4
+ async 2.13.0
+ boolean_selector 2.1.2
+ build 2.5.2
+ build_config 1.1.2
+ build_daemon 4.0.4
+ build_resolvers 2.5.2
+ build_runner 2.5.2
+ build_runner_core 9.1.0
+ built_collection 5.1.1
+ built_value 8.10.1
+ characters 1.4.0
+ checked_yaml 2.0.4
+ child_builder 2.0.2
+ clock 1.1.2
+ code_builder 4.10.1
+ collection 1.19.1
+ convert 3.1.2
+ crypto 3.0.6
+ dart_style 3.1.0
+ dynamic_widget_annotation 3.0.0
+ encrypt 5.0.3
+ execution_timer 1.1.0+13
+ fake_async 1.3.3
+ file 7.0.1
+ fixnum 1.1.1
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 6.0.0
+ flutter_test 0.0.0 from sdk flutter
+ form_validation 3.2.0
+ frontend_server_client 4.0.0
+ glob 2.1.3
+ graphs 2.3.2
+ http 1.4.0
+ http_multi_server 3.2.2
+ http_parser 4.1.2
+ interpolation 2.1.2
+ intl 0.20.2
+ io 1.0.5
+ ionicons 0.2.2
+ ionicons_named 1.3.2+6
+ iregexp 0.1.2
+ js 0.7.2
+ json_annotation 4.9.0
+ json_class 3.0.1
+ json_conditional 3.0.1+17
+ json_dynamic_widget 10.0.1
+ json_dynamic_widget_codegen 3.0.0
+ json_path 0.7.6
+ json_schema 5.2.1
+ json_theme 9.0.1
+ json_theme_annotation 1.0.3+18
+ leak_tracker 10.0.9 (11.0.1 available)
+ leak_tracker_flutter_testing 3.0.9 (3.0.10 available)
+ leak_tracker_testing 3.0.1 (3.0.2 available)
+ lints 6.0.0
+ logging 1.3.0
+ matcher 0.12.17
+ material_color_utilities 0.11.1 (0.13.0 available)
+ maybe_just_nothing 0.5.3
+ meta 1.16.0 (1.17.0 available)
+ mime 2.0.0
+ package_config 2.2.0
+ path 1.9.1
+ petitparser 6.1.0 (7.0.0 available)
+ pointycastle 3.9.1 (4.0.0 available)
+ pool 1.5.1
+ pub_semver 2.2.0
+ pubspec_parse 1.5.0
+ quiver 3.2.2
+ recase 4.1.0
+ rfc_6901 0.2.0
+ rxdart 0.28.0
+ shelf 1.4.2
+ shelf_web_socket 3.0.0
+ sky_engine 0.0.0 from sdk flutter
+ source_gen 2.0.0
+ source_span 1.10.1
+ sprintf 7.0.0
+ stack_trace 1.12.1
+ stream_channel 2.1.4
+ stream_transform 2.1.1
+ string_scanner 1.4.1
+ template_expressions 3.3.1+2
+ term_glyph 1.2.2
+ test_api 0.7.4 (0.7.6 available)
+ timing 1.0.2
+ typed_data 1.4.0
+ uri 1.0.0
+ uuid 4.5.1
+ vector_math 2.1.4 (2.2.0 available)
+ vm_service 15.0.0 (15.0.2 available)
+ watcher 1.1.2
+ web 1.1.1
+ web_socket 1.0.1
+ web_socket_channel 3.0.3
+ yaml 3.1.3
+ yaml_writer 2.1.0
+ yaon 1.1.4+10
Changed 102 dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...


Because every version of json_dynamic_widget_plugin_ionicons from path depends on json_dynamic_widget ^10.0.1 and example depends on json_dynamic_widget ^9.0.0+7, json_dynamic_widget_plugin_ionicons from path is forbidden.
So, because example depends on json_dynamic_widget_plugin_ionicons from path, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on json_dynamic_widget: flutter pub add json_dynamic_widget:^10.0.1
Failed to update packages.

```


dependencies:
  * `json_dynamic_widget`: 9.0.0+7 --> 10.0.1


Analysis Successful

